### PR TITLE
ci: Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -8,10 +8,10 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Bump version and push tag
         id: tag_version
-        uses: RomainEndelin/github-tag-action@v1.0
+        uses: RomainEndelin/github-tag-action@d6d4c3e86ae18c98852973a7e5c59fffc6576b56 # v1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force_bump: minor
@@ -23,7 +23,7 @@ jobs:
           no-print-matched-heading: true
           pattern: "${{ steps.tag_version.outputs.new_tag }}"
       - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: Release ${{ steps.tag_version.outputs.new_tag }}


### PR DESCRIPTION
## What?

This PR pins versions of GitHub Actions to full commit hash. 
In general, this PR doesn't change the behavior of the workflows, so you should be able to merge this safely. 

## Why?

Lately, many popular npm packages and GitHub Actions have been compromised in supply-chain attacks where tags of GitHub Actions were tampered with and they pointed to a revision with malicious code.

- https://nesbitt.io/2026/04/28/github-actions-is-the-weakest-link.html
- https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
- https://safedep.io/mini-shai-hulud-strikes-again-314-npm-packages-compromised/
- https://tanstack.com/blog/incident-followup
- https://safedep.io/mass-npm-supply-chain-attack-tanstack-mistral/

Pinning to a full SHA is a GitHub-recommended best practice ([docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)) and will soon be mandated by an update to our [Secure Software Development Policy](https://ortecfinance.sharepoint.com/:b:/r/sites/Security/Shared%20Documents/Information%20Security%20Policies/Secure%20Software%20Development%20Policy.pdf?csf=1&web=1&e=9BKUgJ).

## Due Date

> [!CAUTION]
> Please merge this pull request by **2026-06-01**
> 
> We are planning to make sha-pinning mandatory for all GitHub Actions in our GitHub Organization. 
> Your GitHub Workflows will fail if the SHAs are not pinned by then.

## Contact

If you have any question, please contact the Chapters.